### PR TITLE
Update lambda_function requirements.txt

### DIFF
--- a/application/eth2/lambda/layer/requirements.txt
+++ b/application/eth2/lambda/layer/requirements.txt
@@ -1,2 +1,2 @@
 cryptography==39.0.2 ; python_version >= "3.9" and python_version < "4"
-requests>=2.28.1 ; python_version >= "3.9" and python_version < "4"
+requests==2.29.0 ; python_version >= "3.9" and python_version < "4"


### PR DESCRIPTION
fix for 'lambda_function': cannot import name 'DEFAULT_CIPHERS'